### PR TITLE
fix: use k8s internal service host name in sql & redis connectstring

### DIFF
--- a/src/Services/Masa.Scheduler.Services.Server/appsettings.Develop.json
+++ b/src/Services/Masa.Scheduler.Services.Server/appsettings.Develop.json
@@ -8,13 +8,13 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=10.10.90.37,30100;Database=masa-scheduler;User Id=sa;Password=p@ssw0rd;"
+    "DefaultConnection": "Server=sqlserver-dev-svc.stack;Database=masa-scheduler;User Id=sa;Password=p@ssw0rd;"
   },
   "RedisConfig": {
     "Servers": [
       {
-        "Host": "10.10.90.37",
-        "Port": "30120"
+        "Host": "redis-dev-svc.stack",
+        "Port": "6379"
       }
     ],
     "DefaultDatabase": 0,

--- a/src/Services/Masa.Scheduler.Services.Server/appsettings.Staging.json
+++ b/src/Services/Masa.Scheduler.Services.Server/appsettings.Staging.json
@@ -8,13 +8,13 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=10.10.90.37,30110;Database=masa-scheduler;User Id=sa;Password=p@ssw0rd;"
+    "DefaultConnection": "Server=sqlserver-test-svc.stack;Database=masa-scheduler;User Id=sa;Password=p@ssw0rd;"
   },
   "RedisConfig": {
     "Servers": [
       {
-        "Host": "10.10.90.114",
-        "Port": "30130"
+        "Host": "redis-test-svc.stack",
+        "Port": "6379"
       }
     ],
     "DefaultDatabase": 0,

--- a/src/Services/Masa.Scheduler.Services.Server/appsettings.Testing.json
+++ b/src/Services/Masa.Scheduler.Services.Server/appsettings.Testing.json
@@ -13,8 +13,8 @@
   "RedisConfig": {
     "Servers": [
       {
-        "Host": "10.10.90.114",
-        "Port": "30130"
+        "Host": "redis-test-svc.stack",
+        "Port": "6379"
       }
     ],
     "DefaultDatabase": 0,

--- a/src/Services/Masa.Scheduler.Services.Worker/appsettings.Develop.json
+++ b/src/Services/Masa.Scheduler.Services.Worker/appsettings.Develop.json
@@ -8,13 +8,13 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=10.10.90.37,30100;Database=masa-scheduler-worker;User Id=sa;Password=p@ssw0rd;"
+    "DefaultConnection": "Server=sqlserver-dev-svc.stack;Database=masa-scheduler-worker;User Id=sa;Password=p@ssw0rd;"
   },
   "RedisConfig": {
     "Servers": [
       {
-        "Host": "10.10.90.37",
-        "Port": "30120"
+        "Host": "redis-dev-svc.stack",
+        "Port": "6379"
       }
     ],
     "DefaultDatabase": 0,

--- a/src/Services/Masa.Scheduler.Services.Worker/appsettings.Staging.json
+++ b/src/Services/Masa.Scheduler.Services.Worker/appsettings.Staging.json
@@ -8,13 +8,13 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=10.10.90.37,30110;Database=masa-scheduler-worker;User Id=sa;Password=p@ssw0rd;"
+    "DefaultConnection": "Server=sqlserver-test-svc.stack;Database=masa-scheduler-worker;User Id=sa;Password=p@ssw0rd;"
   },
   "RedisConfig": {
     "Servers": [
       {
-        "Host": "10.10.90.114",
-        "Port": "30130"
+        "Host": "redis-test-svc.stack",
+        "Port": "6379"
       }
     ],
     "DefaultDatabase": 0,

--- a/src/Services/Masa.Scheduler.Services.Worker/appsettings.Testing.json
+++ b/src/Services/Masa.Scheduler.Services.Worker/appsettings.Testing.json
@@ -13,8 +13,8 @@
   "RedisConfig": {
     "Servers": [
       {
-        "Host": "10.10.90.114",
-        "Port": "30130"
+        "Host": "redis-test-svc.stack",
+        "Port": "6379"
       }
     ],
     "DefaultDatabase": 0,


### PR DESCRIPTION
use k8s internal service host name in sql & redis connectstring