### PR TITLE
style :  rename SecurityTokenDto

### DIFF
--- a/src/ApiGateways/Caller/Masa.Scheduler.ApiGateways.Caller/Services/OssService.cs
+++ b/src/ApiGateways/Caller/Masa.Scheduler.ApiGateways.Caller/Services/OssService.cs
@@ -12,8 +12,8 @@ public class OssService : ServiceBase
         BaseUrl = "api/oss";
     }
 
-    public async Task<SecurityTokenDto> GetSecurityTokenAsync()
+    public async Task<GetSecurityTokenDto> GetSecurityTokenAsync()
     {
-        return await GetAsync<SecurityTokenDto>(nameof(GetSecurityTokenAsync));
+        return await GetAsync<GetSecurityTokenDto>(nameof(GetSecurityTokenAsync));
     }
 }

--- a/src/Contracts/MASA.Scheduler.Contracts.Server/Dtos/GetSecurityTokenDto.cs
+++ b/src/Contracts/MASA.Scheduler.Contracts.Server/Dtos/GetSecurityTokenDto.cs
@@ -3,7 +3,7 @@
 
 namespace Masa.Scheduler.Contracts.Server.Dtos;
 
-public class SecurityTokenDto
+public class GetSecurityTokenDto
 {
     public string Region { get; set; }
 
@@ -15,7 +15,7 @@ public class SecurityTokenDto
 
     public string Bucket { get; set; }
 
-    public SecurityTokenDto(string region, string accessKeyId, string accessKeySecret, string stsToken, string bucket)
+    public GetSecurityTokenDto(string region, string accessKeyId, string accessKeySecret, string stsToken, string bucket)
     {
         Region = region;
         AccessKeyId = accessKeyId;

--- a/src/Services/Masa.Scheduler.Services.Server/Services/OssService.cs
+++ b/src/Services/Masa.Scheduler.Services.Server/Services/OssService.cs
@@ -10,7 +10,7 @@ public class OssService : ServiceBase
 
     }
 
-    public async Task<SecurityTokenDto> GetSecurityTokenAsync([FromServices] IClient client, [FromServices] IOptions<OssOptions> ossOptions)
+    public async Task<GetSecurityTokenDto> GetSecurityTokenAsync([FromServices] IClient client, [FromServices] IOptions<OssOptions> ossOptions)
     {
         var region = "oss-cn-hangzhou";
         var response = client.GetSecurityToken();
@@ -18,6 +18,6 @@ public class OssService : ServiceBase
         var accessId = response.AccessKeyId;
         var accessSecret = response.AccessKeySecret;
         var bucket = ossOptions.Value.Bucket;
-        return await Task.FromResult(new SecurityTokenDto(region, accessId, accessSecret, stsToken, bucket));
+        return await Task.FromResult(new GetSecurityTokenDto(region, accessId, accessSecret, stsToken, bucket));
     }
 }


### PR DESCRIPTION
After renaming, if the ci image is not successfully built, you will be prompted that the SecurityTokenDto cannot be found, and you must go back