### PR TITLE
fix: Dns.GetHostEntryAsync cause an exception on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,7 @@ MigrationBackup/
 /src/Services/Masa.Scheduler.Services.Worker/ResourceFiles
 /src/Services/Masa.Scheduler.Services.Worker/JobShell/runtimes/unix/lib/netcoreapp3.0
 /power.ps1
+
+
+.idea/
+.DS_Store

--- a/src/Contracts/Masa.Scheduler.Contracts.Server/Infrastructure/Extensions/DnsHelper.cs
+++ b/src/Contracts/Masa.Scheduler.Contracts.Server/Infrastructure/Extensions/DnsHelper.cs
@@ -1,0 +1,23 @@
+// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Scheduler;
+
+public static class DnsHelper
+{
+    public static string GetHostName(ILogger? logger=null)
+    {
+        var hostName = Dns.GetHostName();
+        try
+        {
+            var host = Dns.GetHostEntryAsync(hostName).GetAwaiter().GetResult();
+            hostName = host.HostName;
+        }
+        catch (Exception e)
+        {
+            logger?.LogError(e, e.Message);
+        }
+
+        return hostName;
+    }
+}

--- a/src/Contracts/Masa.Scheduler.Contracts.Server/Infrastructure/Managers/BaseSchedulerManager.cs
+++ b/src/Contracts/Masa.Scheduler.Contracts.Server/Infrastructure/Managers/BaseSchedulerManager.cs
@@ -188,9 +188,8 @@ public abstract class BaseSchedulerManager<T, TOnlineEvent, TMonitorEvent> where
             HeartbeatApi = HeartbeatApi,
             Status = ServiceStatus.Normal
         };
-
-        var host = Dns.GetHostEntry(Dns.GetHostName());
-        _data.ServiceId = MD5Utils.Encrypt(EncryptType.Md5, host.HostName);
+        
+        _data.ServiceId = MD5Utils.Encrypt(DnsHelper.GetHostName(Logger));
 
         service.ServiceId = _data.ServiceId;
 

--- a/src/Services/Masa.Scheduler.Services.Server/Application/Jobs/Queries/SchedulerJobQueryByIdentity.cs
+++ b/src/Services/Masa.Scheduler.Services.Server/Application/Jobs/Queries/SchedulerJobQueryByIdentity.cs
@@ -84,5 +84,6 @@ public record SchedulerJobQueryByIdentity(GetSchedulerJobByIdentityRequest Reque
     {
         _eventId = original._eventId;
         _creationTime = original._creationTime;
+        Request = original.Request;
     }
 }

--- a/src/Services/Masa.Scheduler.Services.Worker/Services/SchedulerWorkerManagerService.cs
+++ b/src/Services/Masa.Scheduler.Services.Worker/Services/SchedulerWorkerManagerService.cs
@@ -11,8 +11,7 @@ public class SchedulerWorkerManagerService : ServiceBase
     public SchedulerWorkerManagerService(IServiceCollection services, ILogger<SchedulerWorkerManagerService> logger, SchedulerLogger schedulerLogger) : base(ConstStrings.SCHEDULER_WORKER_MANAGER_API)
     {
         _logger = logger;
-        var host = Dns.GetHostEntry(Dns.GetHostName());
-        var serviceId = MD5Utils.Encrypt(EncryptType.Md5, host.HostName);
+        var serviceId = MD5Utils.Encrypt(DnsHelper.GetHostName(_logger));
         App.MapPost(ConstStrings.SCHEDULER_WORKER_MANAGER_API + "/start", StartTask).WithTopic(ConstStrings.PUB_SUB_NAME, nameof(StartTaskIntegrationEvent) + serviceId);
         App.MapPost(ConstStrings.SCHEDULER_WORKER_MANAGER_API + "/stop", StopTask).WithTopic(ConstStrings.PUB_SUB_NAME, nameof(StopTaskIntegrationEvent) + serviceId);
         _schedulerLogger = schedulerLogger;


### PR DESCRIPTION
1. ignore the exception and use Dns.GetHostName() directly
2. ignore .idea, .DS_Store for source manage

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
