### PR TITLE
fix: globalconfig.CurrentTeamId is not init when page show

### DIFF
--- a/src/Web/Masa.Scheduler.Web.Admin.Server/Program.cs
+++ b/src/Web/Masa.Scheduler.Web.Admin.Server/Program.cs
@@ -4,20 +4,14 @@
 var builder = WebApplication.CreateBuilder(args);
 await builder.Services.AddMasaStackConfigAsync();
 var masaStackConfig = builder.Services.GetMasaStackConfig();
-builder.Services.AddObservable(builder.Logging, () =>
+builder.Services.AddObservable(builder.Logging, () => new MasaObservableOptions
 {
-    return new MasaObservableOptions
-    {
-        ServiceNameSpace = builder.Environment.EnvironmentName,
-        ServiceVersion = masaStackConfig.Version,
-        ServiceName = masaStackConfig.GetWebId(MasaStackConstant.SCHEDULER),
-        Layer = masaStackConfig.Namespace,
-        ServiceInstanceId = builder.Configuration.GetValue<string>("HOSTNAME")
-    };
-}, () =>
-{
-    return masaStackConfig.OtlpUrl;
-}, true);
+    ServiceNameSpace = builder.Environment.EnvironmentName,
+    ServiceVersion = masaStackConfig.Version,
+    ServiceName = masaStackConfig.GetWebId(MasaStackConstant.SCHEDULER),
+    Layer = masaStackConfig.Namespace,
+    ServiceInstanceId = builder.Configuration.GetValue<string>("HOSTNAME")
+}, () => masaStackConfig.OtlpUrl, true);
 
 if (!builder.Environment.IsDevelopment())
 {
@@ -39,7 +33,6 @@ builder.Services.AddServerSideBlazor();
 var authBaseAddress = masaStackConfig.GetAuthServiceDomain();
 var mcBaseAddress = masaStackConfig.GetMcServiceDomain();
 var schedulerBaseAddress = masaStackConfig.GetSchedulerServiceDomain();
-
 #if DEBUG
 schedulerBaseAddress = "https://localhost:19611";
 #endif
@@ -58,7 +51,7 @@ builder.Services.AddScoped<TokenProvider>();
 
 builder.Services.AddMasaSignalRClient(options => options.SignalRServiceUrl = signalRBaseAddress);
 
-MasaOpenIdConnectOptions masaOpenIdConnectOptions = new MasaOpenIdConnectOptions
+MasaOpenIdConnectOptions masaOpenIdConnectOptions = new()
 {
     Authority = masaStackConfig.GetSsoDomain(),
     ClientId = masaStackConfig.GetWebId(MasaStackConstant.SCHEDULER),
@@ -80,10 +73,7 @@ builder.Services.AddSchedulerApiGateways(options =>
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-}
-else
+if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.

--- a/src/Web/Masa.Scheduler.Web.Admin/Pages/Teams/Team.razor.cs
+++ b/src/Web/Masa.Scheduler.Web.Admin/Pages/Teams/Team.razor.cs
@@ -9,6 +9,9 @@ public partial class Team
     public string TeamId { get; set; } = string.Empty;
 
     [Inject]
+    public MasaUser CurrentUser { get; set; } = default!;
+
+    [Inject]
     public Stack.Components.Configs.GlobalConfig StackGlobalConfig { get; set; } = default!;
 
     private Guid _teamId = default;
@@ -28,17 +31,33 @@ public partial class Team
 
     protected async override Task OnAfterRenderAsync(bool firstRender)
     {
-        if (string.IsNullOrEmpty(TeamId))
+        if (firstRender)
         {
-            _teamId = StackGlobalConfig.CurrentTeamId;
+            SetCurrentTeamId(TeamId);
         }
-
         await base.OnAfterRenderAsync(firstRender);
     }
 
     protected override void OnParametersSet()
     {
-        _teamId = string.IsNullOrEmpty(TeamId) ? StackGlobalConfig.CurrentTeamId : Guid.Parse(TeamId);
+        SetCurrentTeamId(TeamId);
+    }
+
+    private void SetCurrentTeamId(string? teamId)
+    {
+        if (string.IsNullOrEmpty(teamId))
+        {
+            _teamId = StackGlobalConfig.CurrentTeamId;
+            if (_teamId == Guid.Empty)
+            {
+                //StackGlobalConfig.CurrentTeamId will only init after component `User` render
+                _teamId = CurrentUser.CurrentTeamId;
+            }
+        }
+        else
+        {
+            _teamId = Guid.Parse(teamId);
+        }
     }
 
     public Task HandleJobSelect(SchedulerJobDto job)


### PR DESCRIPTION
globalconfig.CurrentTeamId will only init after `User` component render

when globalconfig.CurrentTeamId is not init ,use MasaUser.CurrentTeamId instead
